### PR TITLE
Add optional file formatting with query parameters (spaces, tabs, semicolons)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export default defineEndpoint((router, { getSchema, logger }) => {
                 ? Math.floor(parseInt(req.query.spaces?.toString()))
                 : 2,
             useTabs: req.query.useTabs === 'true',
-            trailingSemiColons: req.query.trailingSemiColons === 'true',
+            trailingSemicolons: req.query.trailingSemicolons === 'true',
         };
         await generateTypes(getSchema, logger, options).then((text) =>
             res.send(text),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,21 @@
 import { defineEndpoint } from '@directus/extensions-sdk';
 import { generateTypes } from './services/TypesService';
+import type { GenerateTypesOptions } from './services/TypesService';
 
 export default defineEndpoint((router, { getSchema, logger }) => {
-    router.get(
-        '/',
-        async (_, res) =>
-            await generateTypes(getSchema, logger).then((text) =>
-                res.type('text/plain').send(text),
-            ),
-    );
+    router.get('/', async (req, res) => {
+        res.type('text/plain');
+        res.status(200);
+
+        const options: GenerateTypesOptions = {
+            spaces: req.query.spaces
+                ? Math.floor(parseInt(req.query.spaces?.toString()))
+                : 2,
+            useTabs: req.query.useTabs === 'true',
+            trailingSemiColons: req.query.trailingSemiColons === 'true',
+        };
+        await generateTypes(getSchema, logger, options).then((text) =>
+            res.send(text),
+        );
+    });
 });

--- a/src/services/TypesService.ts
+++ b/src/services/TypesService.ts
@@ -25,7 +25,7 @@ type COLLECTION = {
 export type GenerateTypesOptions = {
     spaces: number;
     useTabs: boolean;
-    trailingSemiColons: boolean;
+    trailingSemicolons: boolean;
 };
 
 const directusTypes = new Set();
@@ -233,14 +233,14 @@ export const generateTypes = async (
                 if (value.field === collection.primary) {
                     ret += `${maybeAddTrailingSlash(
                         ': PrimaryKey',
-                        options.trailingSemiColons,
+                        options.trailingSemicolons,
                     )}\n`;
                     return;
                 }
 
                 ret += maybeAddTrailingSlash(
                     `: ${getType(value)}`,
-                    options.trailingSemiColons,
+                    options.trailingSemicolons,
                 );
                 ret += '\n';
             });
@@ -256,14 +256,14 @@ export const generateTypes = async (
                         : field.field;
                 ret += maybeAddTrailingSlash(
                     `: ${getType(field)}`,
-                    options.trailingSemiColons,
+                    options.trailingSemicolons,
                 ); // TODO: Add ?: here for partials if needed
                 ret += '\n';
             });
 
             ret += `${maybeAddTrailingSlash(
                 '}',
-                options.trailingSemiColons,
+                options.trailingSemicolons,
             )}\n\n`;
         });
 
@@ -278,7 +278,7 @@ export const generateTypes = async (
         .sort()
         .join(', ')} } from '@directus/types'${maybeAddTrailingSlash(
         '',
-        options.trailingSemiColons,
+        options.trailingSemicolons,
     )}\n\n${ret}`;
 
     return ret;

--- a/src/services/TypesService.ts
+++ b/src/services/TypesService.ts
@@ -1,5 +1,7 @@
 import { toPascalCase } from '../utils/toPascalCase';
 import { toSingular } from '../utils/toSingular';
+import { getTabSpaceCount } from '../utils/getTabSpaceCount';
+import { maybeAddTrailingSlash } from '../utils/maybeAddTrailingSlash';
 
 import type { EndpointExtensionContext } from '@directus/extensions';
 
@@ -18,6 +20,12 @@ type COLLECTION = {
     accountability: S[keyof S]['accountability'];
     fields: S[keyof S]['fields'];
     prevFields: S[keyof S]['fields'];
+};
+
+export type GenerateTypesOptions = {
+    spaces: number;
+    useTabs: boolean;
+    trailingSemiColons: boolean;
 };
 
 const directusTypes = new Set();
@@ -172,7 +180,11 @@ const getRelations = (
     return col;
 };
 
-export const generateTypes = async (getSchema: GetSchema, logger: Logger) => {
+export const generateTypes = async (
+    getSchema: GetSchema,
+    logger: Logger,
+    options: GenerateTypesOptions,
+) => {
     if (!getSchema || typeof getSchema !== 'function') {
         return [];
     }
@@ -216,29 +228,43 @@ export const generateTypes = async (getSchema: GetSchema, logger: Logger) => {
 
             // Fields with primitive types
             Object.entries(collection.prevFields).forEach(([key, value]) => {
-                ret += '  ';
+                ret += getTabSpaceCount(options.spaces, options.useTabs);
                 ret += key.includes('-') || key.includes('_') ? `${key}` : key;
                 if (value.field === collection.primary) {
-                    ret += `: PrimaryKey\n`;
+                    ret += `${maybeAddTrailingSlash(
+                        ': PrimaryKey',
+                        options.trailingSemiColons,
+                    )}\n`;
                     return;
                 }
 
-                ret += `: ${getType(value)}\n`;
+                ret += maybeAddTrailingSlash(
+                    `: ${getType(value)}`,
+                    options.trailingSemiColons,
+                );
+                ret += '\n';
             });
 
             // TODO: Make sure to handle partial fields on a type.
 
             // Related fields - fields with relations
             collection.relations.forEach((field) => {
-                ret += '  ';
+                ret += getTabSpaceCount(options.spaces, options.useTabs);
                 ret +=
                     field.field.includes('-') || field.field.includes('_')
                         ? `${field.field}`
                         : field.field;
-                ret += `: ${getType(field)}\n`; // TODO: Add ?: here for partials if needed
+                ret += maybeAddTrailingSlash(
+                    `: ${getType(field)}`,
+                    options.trailingSemiColons,
+                ); // TODO: Add ?: here for partials if needed
+                ret += '\n';
             });
 
-            ret += '}\n\n';
+            ret += `${maybeAddTrailingSlash(
+                '}',
+                options.trailingSemiColons,
+            )}\n\n`;
         });
 
     ret +=
@@ -250,7 +276,10 @@ export const generateTypes = async (getSchema: GetSchema, logger: Logger) => {
 
     ret = `import { ${Array.from(directusTypes)
         .sort()
-        .join(', ')} } from '@directus/types'\n\n${ret}`;
+        .join(', ')} } from '@directus/types'${maybeAddTrailingSlash(
+        '',
+        options.trailingSemiColons,
+    )}\n\n${ret}`;
 
     return ret;
 };

--- a/src/utils/getTabSpaceCount.ts
+++ b/src/utils/getTabSpaceCount.ts
@@ -1,0 +1,7 @@
+export const getTabSpaceCount = (numberOfSpaces = 2, useTabs = false) => {
+    let spaces = '';
+    for (let i = 0; i < numberOfSpaces; i++) {
+        spaces += useTabs ? `\t` : ' ';
+    }
+    return spaces;
+};

--- a/src/utils/maybeAddTrailingSlash.ts
+++ b/src/utils/maybeAddTrailingSlash.ts
@@ -1,0 +1,7 @@
+export const maybeAddTrailingSlash = (
+    str: string,
+    addTrailingSlash = false,
+) => {
+    if (!addTrailingSlash) return str;
+    return `${str};`;
+};


### PR DESCRIPTION
## Features

- Added support for optional file formatting via query parameters
  - The number of spaces used for tabs can be changed from the default of 2 with the `spaces` query parameter
  - Instead of using spaces for tabbing by default, you can use tabs instead with the `useTabs` query parameter set to "true"
  - Semicolons can be added (by default they're not) by passing the `trailingSemicolons` query parameter as "true"

Example URLs:
- Set spaces as 4 and use trailing semicolons: `http://localhost:8055/types?spaces=4&trailingSemicolons=true`
- Use tabs instead of spaces: `http://localhost:8055/types?spaces=1&useTabs=true`